### PR TITLE
Added fixes for older airflow config loading

### DIFF
--- a/airflow_kubernetes_job_operator/config.py
+++ b/airflow_kubernetes_job_operator/config.py
@@ -34,7 +34,7 @@ def get(
     try:
         val = conf.get(AIRFLOW_CONFIG_SECTION_NAME, key)
     except AirflowConfigException as ex:
-        logging.warning(ex)
+        logging.debug(ex)
 
     if issubclass(otype, Enum):
         allow_empty = False

--- a/airflow_kubernetes_job_operator/config.py
+++ b/airflow_kubernetes_job_operator/config.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Type, Dict
 from enum import Enum
 from airflow_kubernetes_job_operator.kube_api.utils import not_empty_string
@@ -5,6 +6,7 @@ from airflow_kubernetes_job_operator.kube_api.config import DEFAULT_KUBE_CONFIG_
 from airflow_kubernetes_job_operator.kube_api.queries import LogLine
 from airflow_kubernetes_job_operator.utils import resolve_path
 from airflow.configuration import conf
+from airflow.exceptions import AirflowConfigException
 from airflow_kubernetes_job_operator.collections import (
     JobRunnerDeletePolicy,
     KubernetesJobOperatorDefaultExecutionResource,
@@ -28,7 +30,11 @@ def get(
 ):
     otype = otype or str if default is None else default.__class__
     collection = collection or AIRFLOW_CONFIG_SECTION_NAME
-    val = conf.get(AIRFLOW_CONFIG_SECTION_NAME, key, fallback=None)
+    val = None
+    try:
+        val = conf.get(AIRFLOW_CONFIG_SECTION_NAME, key)
+    except AirflowConfigException as ex:
+        logging.warning(ex)
 
     if issubclass(otype, Enum):
         allow_empty = False
@@ -57,6 +63,7 @@ DEFAULT_DELETE_POLICY: JobRunnerDeletePolicy = get("delete_policy", JobRunnerDel
 DEFAULT_EXECTION_OBJECT: KubernetesJobOperatorDefaultExecutionResource = get(
     "default_execution_object", KubernetesJobOperatorDefaultExecutionResource.Job
 )
+DEFAULT_KUBERNETES_MAX_RESOURCE_NAME_LENGTH = get("max_job_name_length", 50)
 
 # api config
 LogLine.detect_kubernetes_log_level = get("detect_kubernetes_log_level", True)

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -16,6 +16,7 @@ from airflow_kubernetes_job_operator.config import (
     DEFAULT_EXECTION_OBJECT,
     DEFAULT_DELETE_POLICY,
     DEFAULT_TASK_STARTUP_TIMEOUT,
+    DEFAULT_KUBERNETES_MAX_RESOURCE_NAME_LENGTH,
 )
 
 
@@ -160,7 +161,7 @@ class KubernetesJobOperator(BaseOperator):
     def _create_job_name(cls, name):
         return to_kubernetes_valid_name(
             name,
-            max_length=configuration.conf.getint("kube_job_operator", "max_job_name_length", fallback=50),
+            max_length=DEFAULT_KUBERNETES_MAX_RESOURCE_NAME_LENGTH,
         )
 
     def update_override_params(self, o: dict):

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
@@ -5,6 +5,7 @@ from airflow import configuration
 from airflow_kubernetes_job_operator.job_runner import JobRunnerDeletePolicy
 from airflow_kubernetes_job_operator.utils import resolve_relative_path
 from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator
+from airflow_kubernetes_job_operator.config import DEFAULT_VALIDATE_BODY_ON_INIT
 
 try:
     from airflow.contrib.kubernetes.kubernetes_request_factory import pod_request_factory
@@ -66,7 +67,7 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
         body: str = None,
         body_filepath: str = None,
         delete_policy: Union[str, JobRunnerDeletePolicy] = None,
-        validate_body_on_init: bool = None,
+        validate_body_on_init: bool = DEFAULT_VALIDATE_BODY_ON_INIT,
         wait_for_task_timeout: float = None,
         *args,
         **kwargs,
@@ -167,10 +168,6 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
             delete_policy or JobRunnerDeletePolicy.IfSucceeded
             if is_delete_operator_pod
             else JobRunnerDeletePolicy.Never
-        )
-
-        validate_body_on_init = (
-            configuration.conf.getboolean("kube_job_operator", "validate_body_on_init", fallback=False) or False
         )
 
         if body_filepath is not None:


### PR DESCRIPTION
# Fix
1. Older airflows (<1.10.6) have a different loading config. This would give errors when configs are loaded.