### PR TITLE
Add name change for task ID and add support for name_postfix for task id

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ command | None | A list of commands to be sent. i.e. ["echo","ok"]
 arguments | None | A list of arguments to be sent to the docker image.
 image | None | An image to use. (Overrides the main pod image)
 namespace | None | A namespace to use (Overrides/adds a namespace to main resource)
+name_prefix | task_id | The kubernetes resource(s) name prefix
+name_postfix | None | The kuberntes resource(s) name postfix
+random_name_postfix_length | 8 | Add a random string to all kuberntes resource(s) names if > 0
 envs | None | A dictionary of envs to add to the main job pod.
 body | None | The body of the job to use. Can be string, dictionary.
 body_filepath | None | A filepath to the yaml config file. Can use a relative filepath.

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -62,7 +62,8 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
         arguments: List[str] = None,
         image: str = None,
         name_prefix: str = None,
-        name_postfix: int = None,
+        name_postfix: str = None,
+        random_name_postfix_length: int = 8,
         namespace: str = None,
         envs: dict = None,
         body: Union[str, dict, List[dict]] = None,
@@ -91,7 +92,8 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             arguments (List[str], optional): The kubernetes pod arguments. Defaults to None.
             image (str, optional): The kubernetes container image to use. Defaults to None.
             name_prefix (str, optional): The kubernetes resource(s) name prefix. Defaults to (corrected) task_id.
-            name_postfix (int, optional): Add a random string to all resource names if > 0. Defaults to 8
+            name_postfix (str, optional): The postfix for all resource name. Defaults to None.
+            random_name_postfix_length (int, optional): Add a random string to all resource names if > 0. Defaults to 8.
             namespace (str, optional): The kubernetes namespace to run in. Defaults to current namespace.
             envs (dict, optional): A dictionary of key value pairs that is loaded into the environment variables.
                 Defaults to None.
@@ -166,6 +168,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
         self.body = body
         self.name_prefix = name_prefix
         self.name_postfix = name_postfix
+        self.random_name_postfix_length = random_name_postfix_length
         self.namespace = namespace
         self.get_logs = get_logs
         self.on_kube_api_event = on_kube_api_event
@@ -289,7 +292,8 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             logger=self.logger if hasattr(self, "logger") else None,
             auto_load_kube_config=True,
             name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix or self.task_id),
-            name_postfix=self.name_prefix,
+            name_postfix=self.name_postfix,
+            random_name_postfix_length=random_name_postfix_length,
         )
 
     def get_template_env(self) -> jinja2.Environment:

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -62,6 +62,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
         arguments: List[str] = None,
         image: str = None,
         name_prefix: str = None,
+        name_postfix: int = None,
         namespace: str = None,
         envs: dict = None,
         body: Union[str, dict, List[dict]] = None,
@@ -90,6 +91,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             arguments (List[str], optional): The kubernetes pod arguments. Defaults to None.
             image (str, optional): The kubernetes container image to use. Defaults to None.
             name_prefix (str, optional): The kubernetes resource(s) name prefix. Defaults to (corrected) task_id.
+            name_postfix (int, optional): Add a random string to all resource names if > 0. Defaults to 8
             namespace (str, optional): The kubernetes namespace to run in. Defaults to current namespace.
             envs (dict, optional): A dictionary of key value pairs that is loaded into the environment variables.
                 Defaults to None.
@@ -163,6 +165,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
         self.image_pull_policy = image_pull_policy
         self.body = body
         self.name_prefix = name_prefix
+        self.name_postfix = name_postfix
         self.namespace = namespace
         self.get_logs = get_logs
         self.on_kube_api_event = on_kube_api_event
@@ -286,6 +289,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             logger=self.logger if hasattr(self, "logger") else None,
             auto_load_kube_config=True,
             name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix or self.task_id),
+            name_postfix=self.name_prefix,
         )
 
     def get_template_env(self) -> jinja2.Environment:

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -92,8 +92,8 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             arguments (List[str], optional): The kubernetes pod arguments. Defaults to None.
             image (str, optional): The kubernetes container image to use. Defaults to None.
             name_prefix (str, optional): The kubernetes resource(s) name prefix. Defaults to (corrected) task_id.
-            name_postfix (str, optional): The postfix for all resource name. Defaults to None.
-            random_name_postfix_length (int, optional): Add a random string to all resource names if > 0. Defaults to 8.
+            name_postfix (str, optional): The kuberntes resource(s) name postfix. Defaults to None.
+            random_name_postfix_length (int, optional): Add a random string to all kuberntes resource(s) names if > 0. Defaults to 8.
             namespace (str, optional): The kubernetes namespace to run in. Defaults to current namespace.
             envs (dict, optional): A dictionary of key value pairs that is loaded into the environment variables.
                 Defaults to None.

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -293,7 +293,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             auto_load_kube_config=True,
             name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix or self.task_id),
             name_postfix=self.name_postfix,
-            random_name_postfix_length=random_name_postfix_length,
+            random_name_postfix_length=self.random_name_postfix_length,
         )
 
     def get_template_env(self) -> jinja2.Environment:

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -291,7 +291,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             delete_policy=self.delete_policy,
             logger=self.logger if hasattr(self, "logger") else None,
             auto_load_kube_config=True,
-            name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix or self.task_id),
+            name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix if self.name_prefix is not None else self.task_id),
             name_postfix=self.name_postfix,
             random_name_postfix_length=self.random_name_postfix_length,
         )


### PR DESCRIPTION
Hello
2 parts in this PR.
1 part: fix logic with use of the name_prefix
In your code if set empty string to the name_prefix argument, then function uses task_id. IMHO, if we set empty string to the argument, we don't want to use any prefix to pod name (all other types).

2 part: add name_postfix and random_name_postfix_length to the operator. if we want to use ConfigMap with Job(or Pod) ConfigMap must have not random name (without uuid postfix). So such optional arguments are looking not bad :)