### PR TITLE
Update support for legacy operator (remove <airflow 2.0.0)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+ignore = E203, W503
+max-line-length = 120
+
+exclude = 
+    .*
+    build/*
+    dist/*
+    *.egg-info/*
+    ./jobs/old_jobs/*

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ black = "*"
 flake8 = "*"
 
 [packages]
-sqlalchemy = "< 1.4.0"
 apache-airflow = ">=2.3.3"
 apache-airflow-providers-cncf-kubernetes=">=4.3.0"
 airflow-db-logger = ">=2.0.3"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ black = "*"
 
 [packages]
 sqlalchemy = "< 1.4.0"
-apache-airflow = "==2.3.3"
+apache-airflow = ">=2.3.3"
 apache-airflow-providers-cncf-kubernetes=">=4.3.0"
 airflow-db-logger = ">=2.0.3"
 kubernetes = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 black = "*"
+flake8 = "*"
 
 [packages]
 sqlalchemy = "< 1.4.0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you enjoyed using this repo, please consider posting in the [use cases and te
 7. XCom
 8. Log based events
 9. Tested and working on [google cloud composer](https://cloud.google.com/composer).
-10. Airflow > 2.0.0
+10. Airflow > 2.0.0 (Airflow 1 is supported but deprecated)
 
 ### Two operator classes are available
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you enjoyed using this repo, please consider posting in the [use cases and te
 ### Two operator classes are available
 
 1. KubernetesJobOperator - Supply a kubernetes configuration (yaml file, yaml string or a list of python dictionaries) as the body of the task.
-1. KubernetesLegacyJobOperator (only airflow 2.0 and up) - Defaults to a kubernetes job definition, and supports the same arguments as the KubernetesPodOperator. i.e. replace with the KubernetesPodOperator for legacy support.
+1. KubernetesLegacyJobOperator (only airflow 2.0 and up) - Defaults to a kubernetes job definition, and supports the same arguments as the KubernetesPodOperator. i.e. replace with the KubernetesPodOperator for legacy support. (requires installing apache-airflow-providers-cncf-kubernetes package)
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you enjoyed using this repo, please consider posting in the [use cases and te
 ### Two operator classes are available
 
 1. KubernetesJobOperator - Supply a kubernetes configuration (yaml file, yaml string or a list of python dictionaries) as the body of the task.
-1. KubernetesLegacyJobOperator - Defaults to a kubernetes job definition, and supports the same arguments as the KubernetesPodOperator. i.e. replace with the KubernetesPodOperator for legacy support.
+1. KubernetesLegacyJobOperator (only airflow 2.0 and up) - Defaults to a kubernetes job definition, and supports the same arguments as the KubernetesPodOperator. i.e. replace with the KubernetesPodOperator for legacy support.
 
 # Install
 
@@ -173,30 +173,30 @@ export AIRFLOW__[section]__[item] = value
 
 # Kubernetes job operator input variables
 
-argument| default value | description
-|---|---|---|
-command | None | A list of commands to be sent. i.e. ["echo","ok"]
-arguments | None | A list of arguments to be sent to the docker image.
-image | None | An image to use. (Overrides the main pod image)
-namespace | None | A namespace to use (Overrides/adds a namespace to main resource)
-name_prefix | task_id | The kubernetes resource(s) name prefix
-name_postfix | None | The kuberntes resource(s) name postfix
-random_name_postfix_length | 8 | Add a random string to all kuberntes resource(s) names if > 0
-envs | None | A dictionary of envs to add to the main job pod.
-body | None | The body of the job to use. Can be string, dictionary.
-body_filepath | None | A filepath to the yaml config file. Can use a relative filepath.
-image_pull_policy | Always | The kubernetes image pull policy (str)
-delete_policy | IfSucceeded | The resources delete policy. Can be one of: Always, Never, IfSucceeded, IfFailed (Str)
-in_cluster | None | Use in cluster creds.
-config_file | None | Use this kubernetes config file.
-get_logs | True | Retrive the executing pod logs (for all resources)
-cluster_context | The cluster context name to use.
-startup_timeout_seconds | 10 | The max number of seconds to create the job before timeout is called
-validate_body_on_init | False | Can be set to true only if jinja is disabled. Process the yaml when the object is created.
-enable_jinja| True | Enable jinja on the body (str, or file), and the following args: command, arguments, image, envs, body, namespace, config_file, cluster_context
-jinja_job_args | None | A dictionary or object to be used in the jinja template to render arguments. The jinja args are loaded under the keyword "job".
-on_kube_api_event | None | A method to capture kube api log events. By default is none. log output pattern: `::kube_api:[name]=value`
-parse_xcom_event| json parser | Parse the result of xcom events, `::kube_api:xcom={json values...}`
+| argument                   | default value                    | description                                                                                                                                     |
+| -------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| command                    | None                             | A list of commands to be sent. i.e. ["echo","ok"]                                                                                               |
+| arguments                  | None                             | A list of arguments to be sent to the docker image.                                                                                             |
+| image                      | None                             | An image to use. (Overrides the main pod image)                                                                                                 |
+| namespace                  | None                             | A namespace to use (Overrides/adds a namespace to main resource)                                                                                |
+| name_prefix                | task_id                          | The kubernetes resource(s) name prefix                                                                                                          |
+| name_postfix               | None                             | The kuberntes resource(s) name postfix                                                                                                          |
+| random_name_postfix_length | 8                                | Add a random string to all kuberntes resource(s) names if > 0                                                                                   |
+| envs                       | None                             | A dictionary of envs to add to the main job pod.                                                                                                |
+| body                       | None                             | The body of the job to use. Can be string, dictionary.                                                                                          |
+| body_filepath              | None                             | A filepath to the yaml config file. Can use a relative filepath.                                                                                |
+| image_pull_policy          | Always                           | The kubernetes image pull policy (str)                                                                                                          |
+| delete_policy              | IfSucceeded                      | The resources delete policy. Can be one of: Always, Never, IfSucceeded, IfFailed (Str)                                                          |
+| in_cluster                 | None                             | Use in cluster creds.                                                                                                                           |
+| config_file                | None                             | Use this kubernetes config file.                                                                                                                |
+| get_logs                   | True                             | Retrive the executing pod logs (for all resources)                                                                                              |
+| cluster_context            | The cluster context name to use. |
+| startup_timeout_seconds    | 10                               | The max number of seconds to create the job before timeout is called                                                                            |
+| validate_body_on_init      | False                            | Can be set to true only if jinja is disabled. Process the yaml when the object is created.                                                      |
+| enable_jinja               | True                             | Enable jinja on the body (str, or file), and the following args: command, arguments, image, envs, body, namespace, config_file, cluster_context |
+| jinja_job_args             | None                             | A dictionary or object to be used in the jinja template to render arguments. The jinja args are loaded under the keyword "job".                 |
+| on_kube_api_event          | None                             | A method to capture kube api log events. By default is none. log output pattern: `::kube_api:[name]=value`                                      |
+| parse_xcom_event           | json parser                      | Parse the result of xcom events, `::kube_api:xcom={json values...}`                                                                             |
 
 # Metadata annotations
 

--- a/airflow_kubernetes_job_operator/__init__.py
+++ b/airflow_kubernetes_job_operator/__init__.py
@@ -1,4 +1,4 @@
-from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator
-from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator
-from airflow_kubernetes_job_operator.utils import resolve_relative_path
-from airflow_kubernetes_job_operator.job_runner import JobRunnerDeletePolicy
+from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator  # noqa F401
+from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator  # noqa F401
+from airflow_kubernetes_job_operator.utils import resolve_relative_path  # noqa F401
+from airflow_kubernetes_job_operator.job_runner import JobRunnerDeletePolicy  # noqa F401

--- a/airflow_kubernetes_job_operator/config.py
+++ b/airflow_kubernetes_job_operator/config.py
@@ -22,7 +22,7 @@ DEFAULT_EXECUTION_OBJECT_PATHS: Dict[KubernetesJobOperatorDefaultExecutionResour
 
 AIRFLOW_CONFIG_SECTION_NAME = "kubernetes_job_operator"
 
-AIRFLOW_VERSION = [int(re.sub('\D','',v)) for v in version.split(".")]
+AIRFLOW_VERSION = [int(re.sub(r"\D", "", v)) for v in version.split(".")]
 AIRFLOW_MAJOR_VERSION = AIRFLOW_VERSION[0]
 AIRFLOW_MINOR_VERSION = AIRFLOW_VERSION[1]
 AIRFLOW_PATCH_VERSION = AIRFLOW_VERSION[2]
@@ -102,7 +102,7 @@ SHOW_RUNNER_ID_IN_LOGS: bool = get("show_runner_id", False)
 KUBE_CONFIG_EXTRA_LOCATIONS: str = get("kube_config_extra_locations", "", otype=str, allow_empty=True)
 if not_empty_string(KUBE_CONFIG_EXTRA_LOCATIONS):
     for loc in KUBE_CONFIG_EXTRA_LOCATIONS.split(",").reverse():
-        log = loc.strip()
+        loc = loc.strip()
         if len(loc) == 0:
             continue
         kube_api_config.DEFAULT_KUBE_CONFIG_LOCATIONS.insert(0, loc)

--- a/airflow_kubernetes_job_operator/job_runner.py
+++ b/airflow_kubernetes_job_operator/job_runner.py
@@ -10,7 +10,6 @@ from airflow_kubernetes_job_operator.utils import random_string
 from airflow_kubernetes_job_operator.collections import JobRunnerDeletePolicy, JobRunnerException
 from airflow_kubernetes_job_operator.config import SHOW_RUNNER_ID_IN_LOGS
 from airflow_kubernetes_job_operator.kube_api import (
-    EventHandler,
     KubeApiConfiguration,
     GetAPIVersions,
     KubeLogApiEvent,

--- a/airflow_kubernetes_job_operator/kube_api/__init__.py
+++ b/airflow_kubernetes_job_operator/kube_api/__init__.py
@@ -1,9 +1,8 @@
-from airflow_kubernetes_job_operator.kube_api.client import *
-from airflow_kubernetes_job_operator.kube_api.collections import *
-from airflow_kubernetes_job_operator.kube_api.exceptions import *
-from airflow_kubernetes_job_operator.kube_api.watchers import *
-from airflow_kubernetes_job_operator.kube_api.queries import *
-from airflow_kubernetes_job_operator.kube_api.operations import *
-from airflow_kubernetes_job_operator.kube_api.config import KubeApiConfiguration
-
-from airflow_kubernetes_job_operator.kube_api.utils import kube_logger
+from airflow_kubernetes_job_operator.kube_api.client import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.collections import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.exceptions import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.watchers import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.queries import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.operations import *  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.config import KubeApiConfiguration  # noqa F401
+from airflow_kubernetes_job_operator.kube_api.utils import kube_logger  # noqa F401

--- a/airflow_kubernetes_job_operator/kube_api/collections.py
+++ b/airflow_kubernetes_job_operator/kube_api/collections.py
@@ -393,7 +393,7 @@ class KubeResourceDescriptor:
 
     @property
     def spec(self) -> dict:
-        return self.body.get("spec")
+        return self.body.get("spec", {})
 
     @property
     def status(self) -> dict:
@@ -422,10 +422,6 @@ class KubeResourceDescriptor:
     @property
     def metadata(self) -> dict:
         return self.body.get("metadata", {})
-
-    @property
-    def spec(self) -> dict:
-        return self.body.get("spec", {})
 
     @property
     def api_version(self) -> str:

--- a/airflow_kubernetes_job_operator/kube_api/utils.py
+++ b/airflow_kubernetes_job_operator/kube_api/utils.py
@@ -1,4 +1,3 @@
-import os
 from logging import Logger
 from typing import List
 import logging

--- a/airflow_kubernetes_job_operator/kubernetes_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_job_operator.py
@@ -30,7 +30,6 @@ if IS_AIRFLOW_ONE:
         def __init__(self, **kwargs) -> None:
             super().__init__(**kwargs)
 
-
 else:
     from airflow.models import BaseOperator
 
@@ -93,13 +92,15 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             image (str, optional): The kubernetes container image to use. Defaults to None.
             name_prefix (str, optional): The kubernetes resource(s) name prefix. Defaults to (corrected) task_id.
             name_postfix (str, optional): The kuberntes resource(s) name postfix. Defaults to None.
-            random_name_postfix_length (int, optional): Add a random string to all kuberntes resource(s) names if > 0. Defaults to 8.
+            random_name_postfix_length (int, optional): Add a random string to all kuberntes resource(s) names if > 0.
+                Defaults to 8.
             namespace (str, optional): The kubernetes namespace to run in. Defaults to current namespace.
             envs (dict, optional): A dictionary of key value pairs that is loaded into the environment variables.
                 Defaults to None.
             body (Union[str, dict, List[dict]], optional):
                 The dictionary/list[dictionary] or yaml that defines the job yaml.
-                None = use KubernetesJobOperator default job yaml (https://github.com/LamaAni/KubernetesJobOperator/blob/master/airflow_kubernetes_job_operator/templates/job_default.yaml)
+                None = use KubernetesJobOperator default job yaml
+                    (https://github.com/LamaAni/KubernetesJobOperator/blob/master/airflow_kubernetes_job_operator/templates/job_default.yaml)
             body_filepath (str, optional): A filepath to the job yaml or json configuration. Can be a relative path.
                 Defaults to None -> use body.
             image_pull_policy (str, optional): The kubernetes image pull policy. Defaults to None.
@@ -268,7 +269,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
                     self._update_container_yaml(container=container)
                 self._update_main_container_yaml(containers[0])
 
-                ## adding env resources
+                # adding env resources
         for c in o.values():
             if isinstance(c, dict):
                 self._update_override_params(c)
@@ -291,7 +292,9 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
             delete_policy=self.delete_policy,
             logger=self.logger if hasattr(self, "logger") else None,
             auto_load_kube_config=True,
-            name_prefix=self._create_kubernetes_job_name_prefix(self.name_prefix if self.name_prefix is not None else self.task_id),
+            name_prefix=self._create_kubernetes_job_name_prefix(
+                self.name_prefix if self.name_prefix is not None else self.task_id
+            ),
             name_postfix=self.name_postfix,
             random_name_postfix_length=self.random_name_postfix_length,
         )
@@ -353,7 +356,7 @@ class KubernetesJobOperator(KubernetesJobOperatorDefaultsBase):
                 )
                 has_been_updated = True
             if has_been_updated:
-                self.log.info(f"XCom updated, keys: " + ", ".join(values_dict.keys()))
+                self.log.info("XCom updated, keys: " + ", ".join(values_dict.keys()))
 
     def execute(self, context):
         """Call to execute the kubernetes job.

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
@@ -16,13 +16,11 @@ from airflow_kubernetes_job_operator.config import (
 from airflow_kubernetes_job_operator.kubernetes_legacy_pod_generators import (
     create_legacy_kubernetes_pod,
     Secret,
-    Resources,
-    Affinity,
 )
 
 
 class KubernetesLegacyJobOperator(KubernetesJobOperator):
-    BASE_CONTAINER_NAME:str="main"
+    BASE_CONTAINER_NAME: str = "main"
 
     def __init__(
         self,
@@ -231,17 +229,17 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
         self.volume_mounts = volume_mounts or []
         self.volumes = volumes or []
         self.secrets = secrets or []
-        self.node_selector = node_selector or  {}
+        self.node_selector = node_selector or {}
         self.annotations = annotations or {}
         self.affinity = affinity or {}
-        self.container_resources = self._set_resources(container_resources)
+        self.container_resources = container_resources
         self.image_pull_secrets = image_pull_secrets
         self.service_account_name = service_account_name
         self.hostnetwork = hostnetwork
         self.tolerations = tolerations or []
         self.configmaps = configmaps or []
         self.security_context = security_context or {}
-        self.container_security_context=container_security_context or {}
+        self.container_security_context = container_security_context or {}
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
         self.dnspolicy = dnspolicy
 
@@ -259,14 +257,6 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
         self.env_vars = env_vars
         self.schedulername = schedulername
         self.priority_class_name = priority_class_name
-
-    def _set_resources(self, resources):
-        # Legacy
-        inputResource = Resources()
-        if resources:
-            for item in resources.keys():
-                setattr(inputResource, item, resources[item])
-        return inputResource
 
     def prepare_and_update_body(self):
         # call to prepare the raw body.

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
@@ -1,7 +1,6 @@
-import warnings
 import kubernetes.client as k8s
 
-from typing import List, Optional, Union, Dict
+from typing import List, Union
 from airflow_kubernetes_job_operator.exceptions import KubernetesJobOperatorException
 from airflow_kubernetes_job_operator.kube_api.collections import KubeResourceDescriptor
 from airflow_kubernetes_job_operator.job_runner import JobRunnerDeletePolicy

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
@@ -12,6 +12,7 @@ from airflow_kubernetes_job_operator.config import (
     DEFAULT_EXECUTION_OBJECT_PATHS,
     KubernetesJobOperatorDefaultExecutionResource,
 )
+
 from airflow_kubernetes_job_operator.kubernetes_legacy_pod_generators import (
     create_legacy_kubernetes_pod,
     Volume,

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_job_operator.py
@@ -15,61 +15,60 @@ from airflow_kubernetes_job_operator.config import (
 
 from airflow_kubernetes_job_operator.kubernetes_legacy_pod_generators import (
     create_legacy_kubernetes_pod,
-    Volume,
-    Port,
-    VolumeMount,
     Secret,
     Resources,
     Affinity,
-    PodRuntimeInfoEnv,
 )
 
 
 class KubernetesLegacyJobOperator(KubernetesJobOperator):
+    BASE_CONTAINER_NAME:str="main"
+
     def __init__(
         self,
         *args,
-        namespace: Optional[str] = None,
-        image: Optional[str] = None,
-        name: Optional[str] = None,
-        cmds: Optional[List[str]] = None,
-        arguments: Optional[List[str]] = None,
-        ports: Optional[List[Port]] = None,
-        volume_mounts: Optional[List[VolumeMount]] = None,
-        volumes: Optional[List[Volume]] = None,
-        env_vars: Optional[Union[dict, List[k8s.V1EnvVar]]] = None,
-        env_from: Optional[List[k8s.V1EnvFromSource]] = None,
-        secrets: Optional[List[Secret]] = None,
-        in_cluster: Optional[bool] = None,
-        cluster_context: Optional[str] = None,
-        labels: Optional[Dict] = None,
+        namespace: str = None,
+        image: str = None,
+        name: str = None,
+        random_name_suffix: bool = True,
+        cmds: List[str] = None,
+        arguments: List[str] = None,
+        ports: List[k8s.V1ContainerPort] = None,
+        volume_mounts: List[k8s.V1VolumeMount] = None,
+        volumes: List[k8s.V1Volume] = None,
+        env_vars: List[k8s.V1EnvVar] = None,
+        env_from: List[k8s.V1EnvFromSource] = None,
+        secrets: List[Secret] = None,
+        in_cluster: bool = None,
+        cluster_context: str = None,
+        labels: dict = None,
         reattach_on_restart: bool = True,
         startup_timeout_seconds: int = 120,
         get_logs: bool = True,
-        image_pull_policy: Optional[str] = None,
-        annotations: Optional[Dict] = None,
-        resources: Optional[Resources] = None,
-        affinity: Optional[Affinity] = None,
-        config_file: Optional[str] = None,
-        node_selectors: Optional[dict] = None,
-        node_selector: Optional[dict] = None,
-        image_pull_secrets: Optional[Union[List[k8s.V1LocalObjectReference], str]] = None,
-        service_account_name: Optional[str] = None,
-        is_delete_operator_pod: bool = False,
+        image_pull_policy: str = None,
+        annotations: dict = None,
+        container_resources: k8s.V1ResourceRequirements = None,
+        affinity: k8s.V1Affinity = None,
+        config_file: str = None,
+        node_selector: dict = None,
+        image_pull_secrets: List[k8s.V1LocalObjectReference] = None,
+        service_account_name: str = None,
+        is_delete_operator_pod: bool = True,
         hostnetwork: bool = False,
-        tolerations: Optional[List[k8s.V1Toleration]] = None,
-        security_context: Optional[Dict] = None,
-        dnspolicy: Optional[str] = None,
-        schedulername: Optional[str] = None,
-        full_pod_spec: Optional[k8s.V1Pod] = None,
-        init_containers: Optional[List[k8s.V1Container]] = None,
+        tolerations: List[k8s.V1Toleration] = None,
+        security_context: dict = None,
+        container_security_context: dict = None,
+        dnspolicy: str = None,
+        schedulername: str = None,
+        full_pod_spec: k8s.V1Pod = None,
+        init_containers: List[k8s.V1Container] = None,
         log_events_on_failure: bool = False,
         do_xcom_push: bool = False,
-        pod_template_file: Optional[str] = None,
-        priority_class_name: Optional[str] = None,
-        pod_runtime_info_envs: List[PodRuntimeInfoEnv] = None,
-        termination_grace_period: Optional[int] = None,
-        configmaps: Optional[str] = None,
+        pod_template_file: str = None,
+        priority_class_name: str = None,
+        pod_runtime_info_envs: List[k8s.V1EnvVar] = None,
+        termination_grace_period: int = None,
+        configmaps: List[str] = None,
         # job operator args
         body: str = None,
         body_filepath: str = None,
@@ -91,78 +90,80 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
 
         NOTE: xcom has not been implemented.
 
-        :param image: Docker image you wish to launch. Defaults to dockerhub.io,
-            but fully qualified URLS will point to custom repositories
-        :type image: str
-        :param namespace: the namespace to run within kubernetes
-        :type namespace: str
-        :param name: The name prefix for the executing pod. (default: task_id)
-        :type name: str
+        .. seealso::
+            For more information on how to use this operator, take a look at the guide:
+            :ref:`howto/operator:KubernetesPodOperator`
+
+        .. note::
+            If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__
+            and Airflow is not running in the same cluster, consider using
+            :class:`~airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`, which
+            simplifies the authorization process.
+
+        :param namespace: the namespace to run within kubernetes.
+        :param image: Docker image you wish to launch. Defaults to hub.docker.com,
+            but fully qualified URLS will point to custom repositories. (templated)
+        :param name: name of the pod in which the task will run, will be used (plus a random
+            suffix if random_name_suffix is True) to generate a pod id (DNS-1123 subdomain,
+            containing only [a-z0-9.-]).
+        :param random_name_suffix: if True, will generate a random suffix.
         :param cmds: entrypoint of the container. (templated)
-            The docker images's entrypoint is used if this is not provide.
-        :type cmds: list[str]
+            The docker images's entrypoint is used if this is not provided.
         :param arguments: arguments of the entrypoint. (templated)
             The docker image's CMD is used if this is not provided.
-        :type arguments: list[str]
-        :param image_pull_policy: Specify a policy to cache or always pull an image
-        :type image_pull_policy: str
-        :param image_pull_secrets: Any image pull secrets to be given to the pod.
-                                If more than one secret is required, provide a
-                                comma separated list: secret_a,secret_b
-        :type image_pull_secrets: str
-        :param ports: ports for launched pod
-        :type ports: list
-        :param volume_mounts: volumeMounts for launched pod
-        :type volume_mounts: list[airflow.contrib.kubernetes.volume_mount.VolumeMount]
-        :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes
-        :type volumes: list[airflow.contrib.kubernetes.volume.Volume]
-        :param labels: labels to apply to the Pod
-        :type labels: dict
-        :param startup_timeout_seconds: timeout in seconds to startup the pod
-        :type startup_timeout_seconds: int
-        :param name: name of the task you want to run,
-            will be used to generate a pod id
-        :type name: str
+        :param ports: ports for the launched pod.
+        :param volume_mounts: volumeMounts for the launched pod.
+        :param volumes: volumes for the launched pod. Includes ConfigMaps and PersistentVolumes.
         :param env_vars: Environment variables initialized in the container. (templated)
-        :type env_vars: dict
-        :param secrets: Kubernetes secrets to inject in the container,
+        :param env_from: (Optional) List of sources to populate environment variables in the container.
+        :param secrets: Kubernetes secrets to inject in the container.
             They can be exposed as environment vars or files in a volume.
-        :type secrets: list[airflow.contrib.kubernetes.secret.Secret]
-        :param in_cluster: run kubernetes client with in_cluster configuration (if None autodetect)
-        :type in_cluster: bool
+        :param in_cluster: run kubernetes client with in_cluster configuration.
         :param cluster_context: context that points to kubernetes cluster.
             Ignored when in_cluster is True. If None, current-context is used.
-        :type cluster_context: str
-        :param get_logs: get the stdout of the container as logs of the tasks
-        :type get_logs: bool
+        :param reattach_on_restart: if the worker dies while the pod is running, reattach and monitor
+            during the next try. If False, always create a new pod for each try.
+        :param labels: labels to apply to the Pod. (templated)
+        :param startup_timeout_seconds: timeout in seconds to startup the pod.
+        :param get_logs: get the stdout of the container as logs of the tasks.
+        :param image_pull_policy: Specify a policy to cache or always pull an image.
         :param annotations: non-identifying metadata you can attach to the Pod.
-                            Can be a large range of data, and can include characters
-                            that are not permitted by labels.
-        :type annotations: dict
-        :param resources: A dict containing a group of resources requests and limits
-        :type resources: dict
-        :param affinity: A dict containing a group of affinity scheduling rules
-        :type affinity: dict
-        :param node_selectors: A dict containing a group of scheduling rules
-        :type node_selectors: dict
-        :param config_file: The path to the Kubernetes config file
-        :type config_file: str
+            Can be a large range of data, and can include characters
+            that are not permitted by labels.
+        :param container_resources: resources for the launched pod. (templated)
+        :param affinity: affinity scheduling rules for the launched pod.
+        :param config_file: The path to the Kubernetes config file. (templated)
+            If not specified, default value is ``~/.kube/config``
+        :param node_selector: A dict containing a group of scheduling rules.
+        :param image_pull_secrets: Any image pull secrets to be given to the pod.
+            If more than one secret is required, provide a
+            comma separated list: secret_a,secret_b
+        :param service_account_name: Name of the service account
         :param is_delete_operator_pod: What to do when the pod reaches its final
-            state, or the execution is interrupted.
-            If False (default): do nothing, If True: delete the pod if succeeded
-        :type is_delete_operator_pod: bool
-        :param hostnetwork: If True enable host networking on the pod
-        :type hostnetwork: bool
-        :param tolerations: A list of kubernetes tolerations
-        :type tolerations: list tolerations
-        :param configmaps: A list of configmap names objects that we
-            want mount as env variables
-        :type configmaps: list[str]
-        :param pod_runtime_info_envs: environment variables about
-                                    pod runtime information (ip, namespace, nodeName, podName)
-        :type pod_runtime_info_envs: list[PodRuntimeEnv]
-        :param dnspolicy: Specify a dnspolicy for the pod
-        :type dnspolicy: str
+            state, or the execution is interrupted. If True (default), delete the
+            pod; if False, leave the pod.
+        :param hostnetwork: If True enable host networking on the pod.
+        :param tolerations: A list of kubernetes tolerations.
+        :param security_context: security options the pod should run with (PodSecurityContext).
+        :param container_security_context: security options the container should run with.
+        :param dnspolicy: dnspolicy for the pod.
+        :param schedulername: Specify a schedulername for the pod
+        :param full_pod_spec: The complete podSpec
+        :param init_containers: init container for the launched Pod
+        :param log_events_on_failure: Log the pod's events if a failure occurs
+        :param do_xcom_push: If True, the content of the file
+            /airflow/xcom/return.json in the container will also be pushed to an
+            XCom when the container completes.
+        :param pod_template_file: path to pod template file (templated)
+        :param priority_class_name: priority class name for the launched Pod
+        :param pod_runtime_info_envs: (Optional) A list of environment variables,
+            to be set in the container.
+        :param termination_grace_period: Termination grace period if task killed in UI,
+            defaults to kubernetes default
+        :param configmaps: (Optional) A list of names of config maps from which it collects ConfigMaps
+            to populate the environment variables with. The contents of the target
+            ConfigMap's Data field will represent the key-value pairs as environment variables.
+            Extends env_from.
 
         Added arguments:
 
@@ -230,24 +231,17 @@ class KubernetesLegacyJobOperator(KubernetesJobOperator):
         self.volume_mounts = volume_mounts or []
         self.volumes = volumes or []
         self.secrets = secrets or []
-        if node_selectors:
-            # Node selectors is incorrect based on k8s API
-            warnings.warn("node_selectors is deprecated. Please use node_selector instead.", DeprecationWarning)
-            self.node_selector = node_selectors
-        elif node_selector:
-            self.node_selector = node_selector
-        else:
-            self.node_selector = {}
-
+        self.node_selector = node_selector or  {}
         self.annotations = annotations or {}
         self.affinity = affinity or {}
-        self.resources = self._set_resources(resources)
+        self.container_resources = self._set_resources(container_resources)
         self.image_pull_secrets = image_pull_secrets
         self.service_account_name = service_account_name
         self.hostnetwork = hostnetwork
         self.tolerations = tolerations or []
         self.configmaps = configmaps or []
         self.security_context = security_context or {}
+        self.container_security_context=container_security_context or {}
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
         self.dnspolicy = dnspolicy
 

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -4,15 +4,16 @@ from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLO
 
 
 # Loading libraries with backwards compatability
-if AIRFLOW_MAJOR_VERSION <2:
-    def create_legacy_kubernetes_pod_airflow_from_provider(*args,**kwargs):
+if AIRFLOW_MAJOR_VERSION < 2:
+
+    def create_legacy_kubernetes_pod_airflow_from_provider(*args, **kwargs):
         raise KubernetesJobOperatorException("Kubernetes legacy job operator is supported for airflow 2.0 and up")
+
 else:
 
     from kubernetes.client import CoreV1Api, models as k8s
     from airflow.kubernetes.secret import Secret
     from kubernetes.client.models import V1Secret
-
 
     if TYPE_CHECKING:
         from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator
@@ -45,86 +46,45 @@ else:
                 env_from.append(map)
 
         pod = operator.full_pod_spec or k8s.V1Pod(
-                api_version="v1",
-                kind="Pod",
-                metadata=k8s.V1ObjectMeta(
-                    namespace=operator.namespace,
-                    labels=operator.labels,
-                    name=operator.name_prefix,
-                    annotations=operator.annotations,
-                ),
-                spec=k8s.V1PodSpec(
-                    node_selector=operator.node_selector,
-                    affinity=operator.affinity,
-                    tolerations=operator.tolerations,
-                    init_containers=operator.init_containers,
-                    containers=[
-                        k8s.V1Container(
-                            image=operator.image,
-                            name=operator.BASE_CONTAINER_NAME,
-                            command=operator.command,
-                            ports=operator.ports,
-                            image_pull_policy=operator.image_pull_policy,
-                            resources=operator.container_resources,
-                            volume_mounts=operator.volume_mounts,
-                            args=operator.arguments,
-                            env=operator.env_vars,
-                            env_from=operator.env_from,
-                            security_context=operator.container_security_context,
-                        )
-                    ],
-                    image_pull_secrets=operator.image_pull_secrets,
-                    service_account_name=operator.service_account_name,
-                    host_network=operator.hostnetwork,
-                    security_context=operator.security_context,
-                    dns_policy=operator.dnspolicy,
-                    scheduler_name=operator.schedulername,
-                    restart_policy="Never",
-                    priority_class_name=operator.priority_class_name,
-                    volumes=operator.volumes,
-                ),
-            )
-
-        # pod = operator.full_pod_spec or k8s.V1Pod(
-        #     api_version="v1",
-        #     kind="Pod",
-        #     metadata=k8s.V1ObjectMeta(
-        #         namespace=operator.namespace,
-        #         labels=operator.labels,
-        #         name=operator.name_prefix,
-        #         annotations=operator.annotations,
-        #     ),
-        #     spec=k8s.V1PodSpec(
-        #         termination_grace_period_seconds=operator.termination_grace_period,
-        #         node_selector=operator.node_selector,
-        #         affinity=operator.affinity,
-        #         tolerations=operator.tolerations,
-        #         init_containers=operator.init_containers,
-        #         containers=[
-        #             k8s.V1Container(
-        #                 name="main",
-        #                 image=operator.image,
-        #                 command=operator.command,
-        #                 ports=operator.ports,
-        #                 resources=operator.resources,
-        #                 volume_mounts=operator.volume_mounts,
-        #                 args=operator.arguments,
-        #                 env=env_vars,
-        #                 env_from=env_from,
-        #                 image_pull_policy=operator.image_pull_policy,
-        #             )
-        #         ],
-        #         image_pull_secrets=operator.image_pull_secrets,
-        #         service_account_name=operator.service_account_name,
-        #         host_network=operator.hostnetwork,
-        #         security_context=operator.security_context,
-        #         dns_policy=operator.dnspolicy,
-        #         scheduler_name=operator.schedulername,
-        #         restart_policy="Never",
-        #         priority_class_name=operator.priority_class_name,
-        #         volumes=operator.volumes,
-        #     ),
-        # )
+            api_version="v1",
+            kind="Pod",
+            metadata=k8s.V1ObjectMeta(
+                namespace=operator.namespace,
+                labels=operator.labels,
+                name=operator.name_prefix,
+                annotations=operator.annotations,
+            ),
+            spec=k8s.V1PodSpec(
+                node_selector=operator.node_selector,
+                affinity=operator.affinity,
+                tolerations=operator.tolerations,
+                init_containers=operator.init_containers,
+                containers=[
+                    k8s.V1Container(
+                        image=operator.image,
+                        name=operator.BASE_CONTAINER_NAME,
+                        command=operator.command,
+                        ports=operator.ports,
+                        image_pull_policy=operator.image_pull_policy,
+                        resources=operator.container_resources,
+                        volume_mounts=operator.volume_mounts,
+                        args=operator.arguments,
+                        env=operator.env_vars,
+                        env_from=operator.env_from,
+                        security_context=operator.container_security_context,
+                    )
+                ],
+                image_pull_secrets=operator.image_pull_secrets,
+                service_account_name=operator.service_account_name,
+                host_network=operator.hostnetwork,
+                security_context=operator.security_context,
+                dns_policy=operator.dnspolicy,
+                scheduler_name=operator.schedulername,
+                restart_policy="Never",
+                priority_class_name=operator.priority_class_name,
+                volumes=operator.volumes,
+            ),
+        )
 
         for secret in operator.secrets:
             pod = secret.attach_to_pod(pod)

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -12,6 +12,7 @@ if AIRFLOW_MAJOR_VERSION < 2:
 else:
 
     from kubernetes.client import models as k8s
+    from airflow.kubernetes.secret import Secret  # noqa F401
 
     if TYPE_CHECKING:
         from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, List
 from airflow_kubernetes_job_operator.exceptions import KubernetesJobOperatorException
-from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLOW_MINOR_VERSION, AIRFLOW_PATCH_VERSION
+from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION
 
 
 # Loading libraries with backwards compatability
@@ -11,9 +11,7 @@ if AIRFLOW_MAJOR_VERSION < 2:
 
 else:
 
-    from kubernetes.client import CoreV1Api, models as k8s
-    from airflow.kubernetes.secret import Secret
-    from kubernetes.client.models import V1Secret
+    from kubernetes.client import models as k8s
 
     if TYPE_CHECKING:
         from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -1,171 +1,140 @@
 from typing import TYPE_CHECKING, List
+from airflow_kubernetes_job_operator.exceptions import KubernetesJobOperatorException
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLOW_MINOR_VERSION, AIRFLOW_PATCH_VERSION
 
 
 # Loading libraries with backwards compatability
-if AIRFLOW_MAJOR_VERSION == 1 and AIRFLOW_PATCH_VERSION <= 10:
-    from airflow.contrib.kubernetes.kubernetes_request_factory import pod_request_factory
-    from airflow.contrib.kubernetes import pod_generator
-    from airflow.contrib.kubernetes.pod import Resources
-    from airflow.contrib.kubernetes.volume_mount import VolumeMount
-    from airflow.contrib.kubernetes.volume import Volume
-    from airflow.contrib.kubernetes.secret import Secret
-    from airflow.contrib.kubernetes.pod import Port
-    from typing import Dict as Affinity
-    from airflow.contrib.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+if AIRFLOW_MAJOR_VERSION <2:
+    def create_legacy_kubernetes_pod_airflow_from_provider(*args,**kwargs):
+        raise KubernetesJobOperatorException("Kubernetes legacy job operator is supported for airflow 2.0 and up")
 else:
-    if AIRFLOW_MAJOR_VERSION == 1:
-        from airflow.contrib.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-    elif AIRFLOW_MAJOR_VERSION == 2 and AIRFLOW_MINOR_VERSION < 4:
-        from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
-    else:
-        from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
 
     from kubernetes.client import CoreV1Api, models as k8s
-    from kubernetes.client import (
-        V1ResourceRequirements as Resources,
-        V1Volume as Volume,
-        V1VolumeMount as VolumeMount,
-        V1ContainerPort as Port,
-        V1Affinity as Affinity,
-        V1LocalObjectReference as ImagePullSecret,
-    )
     from airflow.kubernetes.secret import Secret
     from kubernetes.client.models import V1Secret
 
 
-if TYPE_CHECKING:
-    from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator
+    if TYPE_CHECKING:
+        from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator
 
+    def create_legacy_kubernetes_pod_airflow_from_provider(operator: "KubernetesLegacyJobOperator"):
+        env_vars = []
+        if isinstance(env_vars, dict):
+            for k in env_vars.keys():
+                val = env_vars[k]
+                val_from = None
+                if isinstance(val, dict):
+                    val_from = val
+                    val = None
+                env_vars.append(k8s.V1EnvVar(name=k, value=val, value_from=val_from))
 
-def create_legacy_kubernetes_pod_airflow_1_using_request_factory(operator: "KubernetesLegacyJobOperator"):
-    if operator.full_pod_spec:
-        raise Exception("full_pod_spec is not allowed in this version of airflow")
+        elif isinstance(operator.env_vars, list):
+            for env in operator.env_vars:
+                if isinstance(env, k8s.V1EnvVar):
+                    env_vars.append(env)
 
-    pod_body = None
-    # old pod generator
-    gen = pod_generator.PodGenerator()
+        if operator.pod_runtime_info_envs:
+            env_vars.extend([env.to_k8s_client_obj() for env in operator.pod_runtime_info_envs])
 
-    for port in operator.ports:
-        gen.add_port(port)
-    for mount in operator.volume_mounts:
-        gen.add_mount(mount)
-    for volume in operator.volumes:
-        gen.add_volume(volume)
+        env_from: List[k8s.V1EnvFromSource] = operator.env_from or []
 
-    all_labels = {}
-    all_labels.update(operator.labels)
+        for map in operator.configmaps:
+            if isinstance(map, str):
+                env_from.append(k8s.V1EnvFromSource(config_map_ref=map))
+            else:
+                env_from.append(map)
 
-    pod = gen.make_pod(
-        namespace=operator.namespace,
-        image=operator.image,
-        pod_id=operator.name_prefix or "kjo",
-        cmds=operator.command,
-        arguments=operator.arguments,
-        labels=all_labels,
-    )
+        pod = operator.full_pod_spec or k8s.V1Pod(
+                api_version="v1",
+                kind="Pod",
+                metadata=k8s.V1ObjectMeta(
+                    namespace=operator.namespace,
+                    labels=operator.labels,
+                    name=operator.name_prefix,
+                    annotations=operator.annotations,
+                ),
+                spec=k8s.V1PodSpec(
+                    node_selector=operator.node_selector,
+                    affinity=operator.affinity,
+                    tolerations=operator.tolerations,
+                    init_containers=operator.init_containers,
+                    containers=[
+                        k8s.V1Container(
+                            image=operator.image,
+                            name=operator.BASE_CONTAINER_NAME,
+                            command=operator.command,
+                            ports=operator.ports,
+                            image_pull_policy=operator.image_pull_policy,
+                            resources=operator.container_resources,
+                            volume_mounts=operator.volume_mounts,
+                            args=operator.arguments,
+                            env=operator.env_vars,
+                            env_from=operator.env_from,
+                            security_context=operator.container_security_context,
+                        )
+                    ],
+                    image_pull_secrets=operator.image_pull_secrets,
+                    service_account_name=operator.service_account_name,
+                    host_network=operator.hostnetwork,
+                    security_context=operator.security_context,
+                    dns_policy=operator.dnspolicy,
+                    scheduler_name=operator.schedulername,
+                    restart_policy="Never",
+                    priority_class_name=operator.priority_class_name,
+                    volumes=operator.volumes,
+                ),
+            )
 
-    pod.service_account_name = operator.service_account_name
-    pod.secrets = operator.secrets
-    pod.envs = operator.envs or {}
-    pod.image_pull_policy = operator.image_pull_policy
-    pod.image_pull_secrets = operator.image_pull_secrets
-    pod.annotations = operator.annotations
-    pod.resources = operator.resources
-    pod.affinity = operator.affinity
-    pod.node_selectors = operator.node_selector
-    pod.hostnetwork = operator.hostnetwork
-    pod.tolerations = operator.tolerations
-    pod.configmaps = operator.configmaps
-    pod.security_context = operator.security_context
-    pod.pod_runtime_info_envs = operator.pod_runtime_info_envs
-    pod.dnspolicy = operator.dnspolicy
+        # pod = operator.full_pod_spec or k8s.V1Pod(
+        #     api_version="v1",
+        #     kind="Pod",
+        #     metadata=k8s.V1ObjectMeta(
+        #         namespace=operator.namespace,
+        #         labels=operator.labels,
+        #         name=operator.name_prefix,
+        #         annotations=operator.annotations,
+        #     ),
+        #     spec=k8s.V1PodSpec(
+        #         termination_grace_period_seconds=operator.termination_grace_period,
+        #         node_selector=operator.node_selector,
+        #         affinity=operator.affinity,
+        #         tolerations=operator.tolerations,
+        #         init_containers=operator.init_containers,
+        #         containers=[
+        #             k8s.V1Container(
+        #                 name="main",
+        #                 image=operator.image,
+        #                 command=operator.command,
+        #                 ports=operator.ports,
+        #                 resources=operator.resources,
+        #                 volume_mounts=operator.volume_mounts,
+        #                 args=operator.arguments,
+        #                 env=env_vars,
+        #                 env_from=env_from,
+        #                 image_pull_policy=operator.image_pull_policy,
+        #             )
+        #         ],
+        #         image_pull_secrets=operator.image_pull_secrets,
+        #         service_account_name=operator.service_account_name,
+        #         host_network=operator.hostnetwork,
+        #         security_context=operator.security_context,
+        #         dns_policy=operator.dnspolicy,
+        #         scheduler_name=operator.schedulername,
+        #         restart_policy="Never",
+        #         priority_class_name=operator.priority_class_name,
+        #         volumes=operator.volumes,
+        #     ),
+        # )
 
-    # old pod generation.. moving to new one
-    pod_body = pod_request_factory.SimplePodRequestFactory().create(pod)
+        for secret in operator.secrets:
+            pod = secret.attach_to_pod(pod)
 
-    return pod_body
-
-
-def create_legacy_kubernetes_pod_airflow_from_provider(operator: "KubernetesLegacyJobOperator"):
-    env_vars = []
-    if isinstance(env_vars, dict):
-        for k in env_vars.keys():
-            val = env_vars[k]
-            val_from = None
-            if isinstance(val, dict):
-                val_from = val
-                val = None
-            env_vars.append(k8s.V1EnvVar(name=k, value=val, value_from=val_from))
-
-    elif isinstance(operator.env_vars, list):
-        for env in operator.env_vars:
-            if isinstance(env, k8s.V1EnvVar):
-                env_vars.append(env)
-
-    if operator.pod_runtime_info_envs:
-        env_vars.extend([env.to_k8s_client_obj() for env in operator.pod_runtime_info_envs])
-
-    env_from: List[k8s.V1EnvFromSource] = operator.env_from or []
-
-    for map in operator.configmaps:
-        if isinstance(map, str):
-            env_from.append(k8s.V1EnvFromSource(config_map_ref=map))
-        else:
-            env_from.append(map)
-
-    pod = operator.full_pod_spec or k8s.V1Pod(
-        api_version="v1",
-        kind="Pod",
-        metadata=k8s.V1ObjectMeta(
-            namespace=operator.namespace,
-            labels=operator.labels,
-            name=operator.name_prefix,
-            annotations=operator.annotations,
-        ),
-        spec=k8s.V1PodSpec(
-            termination_grace_period_seconds=operator.termination_grace_period,
-            node_selector=operator.node_selector,
-            affinity=operator.affinity,
-            tolerations=operator.tolerations,
-            init_containers=operator.init_containers,
-            containers=[
-                k8s.V1Container(
-                    name="main",
-                    image=operator.image,
-                    command=operator.command,
-                    ports=operator.ports,
-                    resources=operator.resources,
-                    volume_mounts=operator.volume_mounts,
-                    args=operator.arguments,
-                    env=env_vars,
-                    env_from=env_from,
-                    image_pull_policy=operator.image_pull_policy,
-                )
-            ],
-            image_pull_secrets=operator.image_pull_secrets,
-            service_account_name=operator.service_account_name,
-            host_network=operator.hostnetwork,
-            security_context=operator.security_context,
-            dns_policy=operator.dnspolicy,
-            scheduler_name=operator.schedulername,
-            restart_policy="Never",
-            priority_class_name=operator.priority_class_name,
-            volumes=operator.volumes,
-        ),
-    )
-
-    for secret in operator.secrets:
-        pod = secret.attach_to_pod(pod)
-
-    return {
-        "metadata": operator.job_runner.client.api_client.sanitize_for_serialization(pod.metadata),
-        "spec": operator.job_runner.client.api_client.sanitize_for_serialization(pod.spec),
-    }
+        return {
+            "metadata": operator.job_runner.client.api_client.sanitize_for_serialization(pod.metadata),
+            "spec": operator.job_runner.client.api_client.sanitize_for_serialization(pod.spec),
+        }
 
 
 def create_legacy_kubernetes_pod(operator: "KubernetesLegacyJobOperator"):
-    if AIRFLOW_MAJOR_VERSION == 1 and AIRFLOW_PATCH_VERSION <= 10:
-        return create_legacy_kubernetes_pod_airflow_1_using_request_factory(operator)
     return create_legacy_kubernetes_pod_airflow_from_provider(operator)

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, List
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLOW_PATCH_VERSION
+from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLOW_MINOR_VERSION, AIRFLOW_PATCH_VERSION
 
 
 # Loading libraries with backwards compatability
@@ -17,8 +17,11 @@ if AIRFLOW_MAJOR_VERSION == 1 and AIRFLOW_PATCH_VERSION <= 10:
 else:
     if AIRFLOW_MAJOR_VERSION == 1:
         from airflow.contrib.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
-    else:
+    elif AIRFLOW_MAJOR_VERSION == 2 and AIRFLOW_MINOR_VERSION < 4:
         from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
+    else:
+        from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
+
     from kubernetes.client import CoreV1Api, models as k8s
     from kubernetes.client import (
         V1ResourceRequirements as Resources,

--- a/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
+++ b/airflow_kubernetes_job_operator/kubernetes_legacy_pod_generators.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, List
 from airflow_kubernetes_job_operator.exceptions import KubernetesJobOperatorException
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow_kubernetes_job_operator.config import AIRFLOW_MAJOR_VERSION, AIRFLOW_MINOR_VERSION, AIRFLOW_PATCH_VERSION
 
 

--- a/examples/dags/test_job_operator.py
+++ b/examples/dags/test_job_operator.py
@@ -28,4 +28,3 @@ KubernetesJobOperator(
     image="ubuntu",
     command=["bash", "-c", "echo start; sleep 10; echo end"],
 )
-

--- a/examples/dags/test_legacy_job_operator.py
+++ b/examples/dags/test_legacy_job_operator.py
@@ -50,4 +50,3 @@ KubernetesLegacyJobOperator(
     dag=dag,
     is_delete_operator_pod=True,
 )
-

--- a/experimental/core_tester/test_job_runner.py
+++ b/experimental/core_tester/test_job_runner.py
@@ -2,7 +2,6 @@ import kubernetes
 import os
 import yaml
 from utils import logging, load_raw_formatted_file
-from datetime import datetime
 from airflow_kubernetes_job_operator.job_runner import JobRunner
 
 logging.basicConfig(level="INFO")

--- a/experimental/core_tester/test_threaded_kubernetes_ns_watch.py
+++ b/experimental/core_tester/test_threaded_kubernetes_ns_watch.py
@@ -1,6 +1,5 @@
 import kubernetes
 import os
-import yaml
 from utils import logging
 from airflow_kubernetes_job_operator.threaded_kubernetes_resource_watchers import (
     ThreadedKubernetesNamespaceResourcesWatcher,

--- a/experimental/core_tester/test_threaded_kubernetes_watch.py
+++ b/experimental/core_tester/test_threaded_kubernetes_watch.py
@@ -1,6 +1,5 @@
 import kubernetes
 import os
-import yaml
 from utils import logging
 from airflow_kubernetes_job_operator.threaded_kubernetes_watch import ThreadedKubernetesWatchNamspeace
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ def get_version():
 setup(
     name="airflow_kubernetes_job_operator",
     version=get_version(),
-    description="An airflow job operator that executes a task as a Kubernetes job on a cluster, given a job yaml configuration or an image uri.",
+    description=(
+        "An airflow job operator that executes a task as a Kubernetes job on a cluster, "
+        "given a job yaml configuration or an image uri."
+    ),
     long_description="Please see readme.md @ https://github.com/LamaAni/KubernetesJobOperator",
     classifiers=[],
     author="Zav Shotan",

--- a/tests/client/get_api_resources.py
+++ b/tests/client/get_api_resources.py
@@ -1,9 +1,7 @@
 import os
-import yaml
 import json
 import kubernetes
 import kubernetes.config.kube_config
-from tests.utils import logging
 from airflow_kubernetes_job_operator.kube_api import KubeApiRestClient, GetAPIResources, GetAPIVersions
 
 

--- a/tests/client/old_client.py
+++ b/tests/client/old_client.py
@@ -1,2 +1,2 @@
-from kubernetes.client import CoreV1Api
-from kubernetes.client import CustomObjectsApi
+from kubernetes.client import CoreV1Api  # noqa F401
+from kubernetes.client import CustomObjectsApi  # noqa F401

--- a/tests/client/test_client_create_delete.py
+++ b/tests/client/test_client_create_delete.py
@@ -1,5 +1,4 @@
 from tests.utils import logging, load_yaml_objects
-from time import sleep
 from typing import Type
 from airflow_kubernetes_job_operator.kube_api import (
     KubeApiRestClient,

--- a/tests/client/test_single_action.py
+++ b/tests/client/test_single_action.py
@@ -1,11 +1,8 @@
 import os
 import yaml
-import kubernetes
-import kubernetes.config.kube_config
 from tests.utils import logging
-from zthreading.tasks import Task
 from airflow_kubernetes_job_operator.kube_api.client import KubeApiRestClient
-from airflow_kubernetes_job_operator.kube_api import CreateNamespaceResource, DeleteNamespaceResource
+from airflow_kubernetes_job_operator.kube_api import DeleteNamespaceResource
 
 
 def load_yaml_obj_configs(fpath: str):

--- a/tests/dags/__init__.py
+++ b/tests/dags/__init__.py
@@ -9,4 +9,3 @@ KubeApiConfiguration.register_kind(
     api_version="hc.dto.cbsinteractive.com/v1alpha1",
     parse_kind_state=KubeResourceKind.parse_state_job,
 )
-

--- a/tests/dags/test_double_log.py
+++ b/tests/dags/test_double_log.py
@@ -1,4 +1,3 @@
-import os
 from utils import default_args, name_from_file
 from airflow import DAG
 from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator

--- a/tests/dags/test_job_operator.py
+++ b/tests/dags/test_job_operator.py
@@ -82,6 +82,4 @@ KubernetesJobOperator(
 
 
 if __name__ == "__main__":
-    dag.schedule_interval = None
-    dag.clear()
-    dag.run()
+    dag.test()

--- a/tests/dags/test_job_operator_jinja.py
+++ b/tests/dags/test_job_operator_jinja.py
@@ -1,5 +1,4 @@
 from utils import default_args, name_from_file
-from datetime import timedelta
 from airflow import DAG
 from airflow_kubernetes_job_operator import (
     KubernetesJobOperator,

--- a/tests/dags/test_legacy_job_operator.py
+++ b/tests/dags/test_legacy_job_operator.py
@@ -30,17 +30,10 @@ echo "Complete"
 """
 with dag:
     KubernetesLegacyJobOperator(
-        task_id="legacy-test-job-success",
+        task_id="legacy-test-job-success-no-delete",
         image="ubuntu",
         cmds=["bash", "-c", bash_script],
         is_delete_operator_pod=False,
-        secrets=[
-            Secret(
-                deploy_type="volume",
-                deploy_target="/tmp",
-                secret="test-secret",
-            )
-        ],
     )
 
     KubernetesLegacyJobOperator(
@@ -89,6 +82,4 @@ with dag:
     )
 
 if __name__ == "__main__":
-    dag.clear()
-    # dag.clear()
-    dag.run()
+    dag.test()

--- a/tests/dags/test_legacy_job_operator.py
+++ b/tests/dags/test_legacy_job_operator.py
@@ -1,7 +1,7 @@
 from utils import default_args, name_from_file
 import kubernetes.client as k8s
 from airflow import DAG
-from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator, Secret
+from airflow_kubernetes_job_operator.kubernetes_legacy_job_operator import KubernetesLegacyJobOperator
 
 dag = DAG(
     name_from_file(__file__),

--- a/tests/dags/test_multi_container_pod.py
+++ b/tests/dags/test_multi_container_pod.py
@@ -1,5 +1,4 @@
 from utils import default_args, name_from_file
-from datetime import timedelta
 from airflow import DAG
 from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator
 

--- a/tests/dags/test_xcoms.py
+++ b/tests/dags/test_xcoms.py
@@ -1,6 +1,6 @@
 from utils import default_args, name_from_file
 from airflow import DAG
-from datetime import datetime, date
+from datetime import datetime
 
 from airflow.models import TaskInstance
 from airflow.operators.python_operator import PythonOperator

--- a/tests/local_airflow/airflow.cfg
+++ b/tests/local_airflow/airflow.cfg
@@ -1,17 +1,17 @@
 [core]
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository. This path must be absolute.
-dags_folder = /home/zav/code/repos/KubernetesJobOperator/tests/dags
+dags_folder = /home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/dags
 
 # Hostname by providing a path to a callable, which will resolve the hostname.
 # The format is "package.function".
 #
-# For example, default value "socket.getfqdn" means that result from getfqdn() of "socket"
-# package will be used as hostname.
+# For example, default value "airflow.utils.net.getfqdn" means that result from patched
+# version of socket.getfqdn() - see https://github.com/python/cpython/issues/49254.
 #
 # No argument should be required in the function specified.
 # If using IP address as hostname is preferred, use value ``airflow.utils.net.get_host_ip_address``
-hostname_callable = socket.getfqdn
+hostname_callable = airflow.utils.net.getfqdn
 
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
@@ -49,10 +49,10 @@ max_active_runs_per_dag = 16
 # Whether to load the DAG examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to ``False`` in a production
 # environment
-load_examples = False
+load_examples = True
 
 # Path to the folder containing Airflow plugins
-plugins_folder = /home/zav/code/repos/KubernetesJobOperator/tests/plugins
+plugins_folder = /home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/plugins
 
 # Should tasks be executed via forking of the parent process ("False",
 # the speedier option) or by spawning a new python process ("True" slow,
@@ -98,6 +98,11 @@ unit_test_mode = False
 # RCE exploits).
 enable_xcom_pickling = False
 
+# What classes can be imported during deserialization. This is a multi line value.
+# The individual items will be parsed as regexp. Python built-in classes (like dict)
+# are always allowed
+allowed_deserialization_classes = airflow\..*
+
 # When a task is killed forcefully, this is the amount of time in seconds that
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
 killed_task_cleanup_time = 60
@@ -116,6 +121,10 @@ dag_ignore_file_syntax = regexp
 
 # The number of retries each task is going to have by default. Can be overridden at dag or task level.
 default_task_retries = 0
+
+# The number of seconds each task is going to wait by default between retries. Can be overridden at
+# dag or task level.
+default_task_retry_delay = 300
 
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
@@ -178,12 +187,28 @@ default_pool_task_slot_count = 128
 # mapped tasks from clogging the scheduler.
 max_map_length = 1024
 
+# The default umask to use for process when run in daemon mode (scheduler, worker,  etc.)
+#
+# This controls the file-creation mode mask which determines the initial value of file permission bits
+# for newly created files.
+#
+# This value is treated as an octal-integer.
+daemon_umask = 0o077
+
+# Class to use as dataset manager.
+# Example: dataset_manager_class = airflow.datasets.manager.DatasetManager
+# dataset_manager_class =
+
+# Kwargs to supply to dataset manager.
+# Example: dataset_manager_kwargs = {"some_param": "some_value"}
+# dataset_manager_kwargs =
+
 [database]
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engines.
 # More information here:
 # http://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#database-uri
-sql_alchemy_conn = sqlite:////home/zav/code/repos/KubernetesJobOperator/tests/local_airflow/airflow.db
+sql_alchemy_conn = sqlite:////home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/airflow.db
 
 # Extra engine specific keyword args passed to SQLAlchemy's create_engine, as a JSON-encoded value
 # Example: sql_alchemy_engine_args = {"arg1": True}
@@ -192,7 +217,8 @@ sql_alchemy_conn = sqlite:////home/zav/code/repos/KubernetesJobOperator/tests/lo
 # The encoding for the databases
 sql_engine_encoding = utf-8
 
-# Collation for ``dag_id``, ``task_id``, ``key`` columns in case they have different encoding.
+# Collation for ``dag_id``, ``task_id``, ``key``, ``external_executor_id`` columns
+# in case they have different encoding.
 # By default this collation is the same as the database collation, however for ``mysql`` and ``mariadb``
 # the default is ``utf8mb3_bin`` so that the index sizes of our index keys will not exceed
 # the maximum size of allowed index when collation is set to ``utf8mb4`` variant
@@ -255,7 +281,7 @@ max_db_retries = 3
 # There are a few existing configurations that assume this is set to the default.
 # If you choose to override this you may need to update the dag_processor_manager_log_location and
 # dag_processor_manager_log_location settings as well.
-base_log_folder = /home/zav/code/repos/KubernetesJobOperator/tests/local_airflow/logs
+base_log_folder = /home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/logs
 
 # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
 # Set this to True if you want to enable remote logging.
@@ -316,6 +342,13 @@ colored_formatter_class = airflow.utils.log.colored_log.CustomTTYColoredFormatte
 log_format = [%%(asctime)s] {%%(filename)s:%%(lineno)d} %%(levelname)s - %%(message)s
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
+# Where to send dag parser logs. If "file", logs are sent to log files defined by child_process_log_directory.
+dag_processor_log_target = file
+
+# Format of Dag Processor Log line
+dag_processor_log_format = [%%(asctime)s] [SOURCE:DAG_PROCESSOR] {%%(filename)s:%%(lineno)d} %%(levelname)s - %%(message)s
+log_formatter_class = airflow.utils.log.timezone_aware.TimezoneAware
+
 # Specify prefix pattern like mentioned below with stream handler TaskHandlerWithCustomFormatter
 # Example: task_log_prefix_template = {ti.dag_id}-{ti.task_id}-{execution_date}-{try_number}
 task_log_prefix_template =
@@ -327,7 +360,7 @@ log_filename_template = dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{
 log_processor_filename_template = {{ filename }}.log
 
 # Full path of dag_processor_manager logfile.
-dag_processor_manager_log_location = /home/zav/code/repos/KubernetesJobOperator/tests/local_airflow/logs/dag_processor_manager/dag_processor_manager.log
+dag_processor_manager_log_location = /home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/logs/dag_processor_manager/dag_processor_manager.log
 
 # Name of handler to read task instance logs.
 # Defaults to use ``task`` handler.
@@ -545,7 +578,7 @@ reload_on_plugin_change = False
 # The token generated using the secret key has a short expiry time though - make sure that time on
 # ALL the machines that you run airflow components on is synchronized (for example using ntpd)
 # otherwise you might get "forbidden" errors when the logs are accessed.
-secret_key = uvfQ49phvpVIlJSzXf39xA==
+secret_key = Cty3YyhqmtmtkYwcSBNALQ==
 
 # Number of workers to run the Gunicorn web server
 workers = 4
@@ -565,14 +598,16 @@ error_logfile = -
 # documentation - https://docs.gunicorn.org/en/stable/settings.html#access-log-format
 access_logformat =
 
-# Expose the configuration file in the web server
+# Expose the configuration file in the web server. Set to "non-sensitive-only" to show all values
+# except those that have security implications. "True" shows all values. "False" hides the
+# configuration completely.
 expose_config = False
 
 # Expose hostname in the web server
 expose_hostname = True
 
 # Expose stacktrace in the web server
-expose_stacktrace = True
+expose_stacktrace = False
 
 # Default DAG view. Valid values are: ``grid``, ``graph``, ``duration``, ``gantt``, ``landing_times``
 dag_default_view = grid
@@ -798,11 +833,6 @@ worker_prefetch_multiplier = 1
 # prevent this by setting this to false. However, with this disabled Flower won't work.
 worker_enable_remote_control = true
 
-# Umask that will be used when starting workers with the ``airflow celery worker``
-# in daemon mode. This control the file-creation mode mask which determines the initial
-# value of file permission bits for newly created files.
-worker_umask = 0o077
-
 # The Celery broker URL. Celery supports RabbitMQ, Redis and experimentally
 # a sqlalchemy database. Refer to the Celery documentation for more information.
 broker_url = redis://redis:6379/0
@@ -812,8 +842,10 @@ broker_url = redis://redis:6379/0
 # or insert it into a database (depending of the backend)
 # This status is used by the scheduler to update the state of the task
 # The use of a database is highly recommended
+# When not specified, sql_alchemy_conn with a db+ scheme prefix will be used
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
-result_backend = db+postgresql://postgres:airflow@postgres/airflow
+# Example: result_backend = db+postgresql://postgres:airflow@postgres/airflow
+# result_backend =
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it ``airflow celery flower``. This defines the IP that Celery Flower runs on
@@ -929,8 +961,9 @@ scheduler_idle_sleep_time = 1
 min_file_process_interval = 30
 
 # How often (in seconds) to check for stale DAGs (DAGs which are no longer present in
-# the expected files) which should be deactivated.
-deactivate_stale_dags_interval = 60
+# the expected files) which should be deactivated, as well as datasets that are no longer
+# referenced and should be marked as orphaned.
+parsing_cleanup_interval = 60
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
 dag_dir_list_interval = 300
@@ -946,9 +979,17 @@ pool_metrics_interval = 5.0
 # This is used by the health check in the "/health" endpoint
 scheduler_health_check_threshold = 30
 
+# When you start a scheduler, airflow starts a tiny web server
+# subprocess to serve a health check if this is set to True
+enable_health_check = False
+
+# When you start a scheduler, airflow starts a tiny web server
+# subprocess to serve a health check on this port
+scheduler_health_check_server_port = 8974
+
 # How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs
 orphaned_tasks_check_interval = 300.0
-child_process_log_directory = /home/zav/code/repos/KubernetesJobOperator/tests/local_airflow/logs/scheduler
+child_process_log_directory = /home/zshotan/repos/public/KubernetesJobOperator/tests/local_airflow/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the
@@ -1020,6 +1061,10 @@ standalone_dag_processor = False
 # in database. Contains maximum number of callbacks that are fetched during a single loop.
 max_callbacks_per_loop = 20
 
+# Only applicable if `[scheduler]standalone_dag_processor` is true.
+# Time in seconds after which dags, which were not updated by Dag Processor are deactivated.
+dag_stale_not_seen_duration = 600
+
 # Turn off scheduler use of cron intervals by setting this to False.
 # DAGs submitted manually in the web UI or with trigger_dag will still run.
 use_job_schedule = True
@@ -1027,9 +1072,6 @@ use_job_schedule = True
 # Allow externally triggered DagRuns for Execution Dates in the future
 # Only has effect if schedule_interval is set to None in DAG
 allow_trigger_in_future = False
-
-# DAG dependency detector class to use
-dependency_detector = airflow.serialization.serialized_objects.DependencyDetector
 
 # How often to check for expired trigger requests that have not run yet.
 trigger_timeout_check_interval = 15
@@ -1052,9 +1094,6 @@ forwardable = True
 
 # Allow to remove source IP from token, useful when using token behind NATted Docker host.
 include_ip = True
-
-[github_enterprise]
-api_rev = v3
 
 [elasticsearch]
 # Elasticsearch host
@@ -1091,7 +1130,7 @@ offset_field = offset
 use_ssl = False
 verify_certs = True
 
-[kubernetes]
+[kubernetes_executor]
 # Path to the YAML pod file that forms the basis for KubernetesExecutor workers.
 pod_template_file =
 
@@ -1187,18 +1226,3 @@ worker_pods_pending_timeout_batch_size = 100
 [sensors]
 # Sensor default timeout, 7 days by default (7 * 24 * 60 * 60).
 default_timeout = 604800
-
-[smart_sensor]
-# When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to
-# smart sensor task.
-use_smart_sensor = False
-
-# `shard_code_upper_limit` is the upper limit of `shard_code` value. The `shard_code` is generated
-# by `hashcode % shard_code_upper_limit`.
-shard_code_upper_limit = 10000
-
-# The number of running smart sensor processes for each service.
-shards = 5
-
-# comma separated sensor classes support in smart_sensor.
-sensors_enabled = NamedHivePartitionSensor

--- a/tests/local_airflow/configure
+++ b/tests/local_airflow/configure
@@ -10,12 +10,22 @@ fi
 CUR_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 REPO_PATH="$(realpath "$CUR_DIR/../../")"
 
+mkdir -p "$REPO_PATH/.local" "$REPO_PATH/.local/logs" || exit $?
+
 export PYTHONPATH="$REPO_PATH"
 export AIRFLOW_HOME="$REPO_PATH/tests/local_airflow"
+export AIRFLOW_CONFIG="$REPO_PATH/.local/airflow.cfg"
 export AIRFLOW__CORE__DAGS_FOLDER="$REPO_PATH/tests/dags"
 export AIRFLOW__CORE__PLUGINS_FOLDER="$REPO_PATH/tests/plugins"
 export AIRFLOW__CORE__BASE_LOG_FOLDER="$REPO_PATH/.local/logs"
+export AIRFLOW__LOGGING__BASE_LOG_FOLDER="$REPO_PATH/.local/logs"
+export AIRFLOW__WEBSERVER__RBAC="False"
+export AIRFLOW__WEBSERVER__AUTHENTICATE="False"
+
 SQLITE_DB_FILE="$REPO_PATH/.local/airflow.db"
 export AIRFLOW__CORE__SQL_ALCHEMY_CONN="sqlite:///${SQLITE_DB_FILE}"
+export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN="sqlite:///${SQLITE_DB_FILE}"
 echo "PYTHONPATH=$PYTHONPATH"
-env | grep "AIRFLOW"
+
+env | grep "AIRFLOW" >|"$REPO_PATH/.local/airflow.env"
+cat "$REPO_PATH/.local/airflow.env"

--- a/tests/local_airflow/load_lib_test.py
+++ b/tests/local_airflow/load_lib_test.py
@@ -1,3 +1,1 @@
-from airflow_kubernetes_job_operator.kubernetes_job_operator import (
-    KubernetesJobOperator,
-)
+from airflow_kubernetes_job_operator.kubernetes_job_operator import KubernetesJobOperator  # noqa F401

--- a/tests/local_airflow/start
+++ b/tests/local_airflow/start
@@ -10,7 +10,9 @@ fi
 CUR_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 REPO_PATH="$(realpath "$CUR_DIR/../../")"
 
-source "$REPO_PATH/.env" || exit $?
+[ -f "$REPO_PATH/.env" ] && {
+  source "$REPO_PATH/.env" || exit $?
+}
 source "$CUR_DIR/configure" || exit $?
 
 if [ "$1" == "reset" ]; then

--- a/tests/local_airflow/tester.py
+++ b/tests/local_airflow/tester.py
@@ -1,5 +1,4 @@
 import pickle
-import kubernetes.config
 
 
 print(pickle.HIGHEST_PROTOCOL)

--- a/tests/local_airflow/webserver_config.py
+++ b/tests/local_airflow/webserver_config.py
@@ -15,16 +15,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Default configuration for the Airflow webserver"""
+"""Default configuration for the Airflow webserver."""
+from __future__ import annotations
+
 import os
 
-from flask_appbuilder.security.manager import AUTH_DB
+from airflow.www.fab_security.manager import AUTH_DB
 
-# from flask_appbuilder.security.manager import AUTH_LDAP
-# from flask_appbuilder.security.manager import AUTH_OAUTH
-# from flask_appbuilder.security.manager import AUTH_OID
-# from flask_appbuilder.security.manager import AUTH_REMOTE_USER
-
+# from airflow.www.fab_security.manager import AUTH_LDAP
+# from airflow.www.fab_security.manager import AUTH_OAUTH
+# from airflow.www.fab_security.manager import AUTH_OID
+# from airflow.www.fab_security.manager import AUTH_REMOTE_USER
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 
@@ -47,13 +48,13 @@ WTF_CSRF_ENABLED = True
 AUTH_TYPE = AUTH_DB
 
 # Uncomment to setup Full admin role name
-# AUTH_ROLE_ADMIN = 'Admin'
+AUTH_ROLE_ADMIN = "Admin"
 
-# Uncomment to setup Public role name, no authentication needed
-AUTH_ROLE_PUBLIC = 'Admin'
+# Uncomment and set to desired role to enable access without authentication
+AUTH_ROLE_PUBLIC = "Admin"
 
 # Will allow user self registration
-# AUTH_USER_REGISTRATION = True
+AUTH_USER_REGISTRATION = False
 
 # The recaptcha it's automatically enabled for user self registration is active and the keys are necessary
 # RECAPTCHA_PRIVATE_KEY = PRIVATE_KEY

--- a/tests/tests/logs/scheduler/latest
+++ b/tests/tests/logs/scheduler/latest
@@ -1,1 +1,0 @@
-/Users/Zshot0831/personal/KubernetesJobOperator/tests/tests/logs/scheduler/2020-09-21

--- a/tests/tests/test.py
+++ b/tests/tests/test.py
@@ -1,2 +1,3 @@
 from airflow import version
+
 print(version.version)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,7 +65,7 @@ def load_default_kube_config():
         -----------------------------------------------------------------------
         Context: {KubeApiConfiguration.get_active_context_info(config)}
         home directory: {os.path.expanduser('~')}
-        Config host: {config.host} 
+        Config host: {config.host}
         Config filepath: {config.filepath}
         Default namespace: {KubeApiConfiguration.get_default_namespace(config)}
         Executing dags in python version: {print_version}

--- a/tests/watcher/raw_logger_test.py
+++ b/tests/watcher/raw_logger_test.py
@@ -1,11 +1,6 @@
 import kubernetes
-import os
-import yaml
-
-import dateutil.parser
-from datetime import datetime
 from tests.watcher.utils import logging
-from airflow_kubernetes_job_operator.kube_api.watchers import KubeApiPodLogWatcher, KubeApiNamespaceWatcherKind
+from airflow_kubernetes_job_operator.kube_api.watchers import KubeApiPodLogWatcher
 
 logging.basicConfig(level="INFO")
 

--- a/tests/watcher/raw_watcher_tester.py
+++ b/tests/watcher/raw_watcher_tester.py
@@ -1,9 +1,4 @@
 import kubernetes
-import os
-import yaml
-
-import dateutil.parser
-from datetime import datetime
 from tests.watcher.utils import logging
 from airflow_kubernetes_job_operator.kube_api.watchers import KubeApiNamespaceWatcher, KubeApiNamespaceWatcherKind
 


### PR DESCRIPTION
Removed:
1. Support for legacy operator for lower then airflow 2.0.0

Added:
1. Support for not loading airflow kubernetes pod operator